### PR TITLE
feat: support RecMode

### DIFF
--- a/soe/speaking_assessment.go
+++ b/soe/speaking_assessment.go
@@ -115,6 +115,7 @@ type SpeechRecognizer struct {
 	ScoreCoeff          float64
 	ServerEngineType    string
 	SentenceInfoEnabled int64
+	RecMode             int
 
 	Credential *common.Credential
 	//listener
@@ -415,6 +416,7 @@ func (recognizer *SpeechRecognizer) buildURL(voiceID string) string {
 	queryMap["score_coeff"] = fmt.Sprintf("%1f", recognizer.ScoreCoeff)
 	queryMap["server_engine_type"] = recognizer.ServerEngineType
 	queryMap["sentence_info_enabled"] = strconv.FormatInt(int64(recognizer.SentenceInfoEnabled), 10)
+	queryMap["rec_mode"] = strconv.FormatInt(int64(recognizer.RecMode), 10)
 
 	var keys []string
 	for k := range queryMap {


### PR DESCRIPTION
示例中使用了 RecMode，但实际上 SDK 没有这个参数。这个 PR 添加对应的同名参数，使 RecMode=1（录音模式）可以使用

[示例程序](https://github.com/TencentCloud/tencentcloud-speech-sdk-go/blob/master/examples/soeexample/main.go) [文档](https://cloud.tencent.com/document/product/1774/107497)